### PR TITLE
refactor: replace biased sort shuffle with Fisher-Yates algorithm

### DIFF
--- a/app/lib/generateSeedPlaylist.ts
+++ b/app/lib/generateSeedPlaylist.ts
@@ -113,7 +113,7 @@ export async function generateSeedPlaylist(
 		const albums = await getEveryAlbum(finalList, signal);
 		throwIfAborted();
 
-		const aiTracks = (await getAllTracks(albums as string[], 5, true, signal)) as any[]; // Need more tracks to filter down
+		const aiTracks = (await getAllTracks(albums as string[], 3, true, signal)) as any[];
 
 		let fallbackTracksUris: string[] = [];
 

--- a/app/lib/generateSeedPlaylist.ts
+++ b/app/lib/generateSeedPlaylist.ts
@@ -113,7 +113,7 @@ export async function generateSeedPlaylist(
 		const albums = await getEveryAlbum(finalList, signal);
 		throwIfAborted();
 
-		const aiTracks = (await getAllTracks(albums as string[], 3, true, signal)) as any[];
+		const aiTracks = (await getAllTracks(albums as string[], 2, true, signal)) as any[];
 
 		let fallbackTracksUris: string[] = [];
 

--- a/app/lib/spotify.ts
+++ b/app/lib/spotify.ts
@@ -2,7 +2,7 @@ import { playlistDetails, singleTrack, trackTypes } from "../types";
 import spotifyApi, { setAccessToken } from './spotifyApi';
 import { getDummyAccessToken } from './spotify-dummy-auth';
 
-import { convertToSubArray } from './utils';
+import { convertToSubArray, shuffle } from './utils';
 
 /**
  * Retrieves all tracks in a Spotify playlist using the provided link.
@@ -143,7 +143,7 @@ export async function getArtistsAlbums(artist: string, artistsLength: number) {
 		if (maxAlbums >= result.length) {
 			return result.map((item: { id: any }) => item.id);
 		} else {
-			const sortedAlbum = result.sort(() => Math.random() - 0.5);
+			const sortedAlbum = shuffle(result);
 			const randomlySelectedAlbum = sortedAlbum
 				.slice(0, maxAlbums)
 				.map((item: { id: any }) => item.id);
@@ -274,7 +274,7 @@ export async function getRelatedArtists(
 	signal?: AbortSignal,
 ): Promise<string[]> {
 	try {
-		const url = `https://ws.audioscrobbler.com/2.0/?method=artist.getsimilar&artist=${encodeURIComponent(artistName)}&api_key=${process.env.LASTFM_API_KEY}&format=json&limit=20`;
+		const url = `https://ws.audioscrobbler.com/2.0/?method=artist.getsimilar&artist=${encodeURIComponent(artistName)}&api_key=${process.env.LASTFM_API_KEY}&format=json&limit=60`;
 
 		const res = await fetch(url, { signal });
 		const data = await res.json();
@@ -287,13 +287,13 @@ export async function getRelatedArtists(
 		}[];
 
 		if (options.isNotPopular) {
-			artists = artists.filter((a) => parseInt(a.listeners) < 500000)
+			artists = artists.filter((a) => parseInt(a.listeners) < 500000);
 		}
 
 		// Last.fm doesn't have a "different genre" concept easily
-    // so just return all for isDifferent and let lyrical similarity handle it
-    const finalArtist = artists.map((a) => a.name);
-		return finalArtist.sort(() => Math.random() - 0.5)
+		// so just return all for isDifferent and let lyrical similarity handle it
+		const finalArtist = artists.map((a) => a.name);
+		return shuffle(finalArtist);
 	} catch (err: any) {
 		if (signal?.aborted) throw new Error('Aborted');
 		console.error(`Error getting related artists for ${artistName}:`, err);

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -33,15 +33,13 @@ export const getEveryAlbum = async (
 	signal?: AbortSignal,
 ) => {
 	if (signal?.aborted) throw new Error('Aborted');
-	const shuffled = [...artists].sort(() => Math.random() - 0.5);
+	const shuffled = shuffle(artists);
 	const artistAlbums = shuffled.map((item) =>
 		getArtistsAlbums(item, shuffled.length),
 	);
 	const albumArray = await Promise.all(artistAlbums);
 	if (signal?.aborted) throw new Error('Aborted');
-	const albums = [...new Set(albumArray.flat())].sort(
-		() => Math.random() - 0.5,
-	);
+	const albums = shuffle([...new Set(albumArray.flat())]);
 	const stringAlbums = albums.filter((item) => typeof item === 'string');
 
 	return stringAlbums;
@@ -279,7 +277,7 @@ export async function relatedArists(
 		const results = await Promise.all(
 			batch.map(async (name) => {
 				const related = await getRelatedArtists(name, options, signal);
-				return related.sort(() => Math.random() - 0.5);
+				return shuffle(related);
 			}),
 		);
 		relatedArtistsPerSeed.push(...results);
@@ -288,6 +286,7 @@ export async function relatedArists(
 	}
 
 	// Round robin — take one from each artist at a time until we have 20
+	shuffle(relatedArtistsPerSeed);
 	const finalList: string[] = [];
 	const excluded = new Set(artistNames.map((n) => n.toLowerCase()));
 	let round = 0;
@@ -446,4 +445,13 @@ export function cleanMusicMetadata(text: string): string {
 			.replace(/\s+/g, ' ')
 			.trim()
 	);
+}
+
+export function shuffle<T>(array: T[]): T[] {
+	const arr = [...array];
+	for (let i = arr.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[arr[i], arr[j]] = [arr[j], arr[i]];
+	}
+	return arr;
 }


### PR DESCRIPTION
# Fixes Issue

**This PR closes #46 **

## 👨‍💻 Changes proposed(What did you do ?)
- Replace `sort(() => Math.random() - 0.5)` with proper `shuffle()` implementation
  using Fisher-Yates algorithm for unbiased randomization across all modules
- Add reusable `shuffle<T>()` utility function in utils.ts
- Increase Last.fm API limit from 20 to 60 for broader artist discovery
- Reduce tracks fetched per album from 5 to 2 in seed playlist generation

## ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
